### PR TITLE
Hotfix/2.1.1 - Setting MongoDB Sample Data ENV

### DIFF
--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -102,7 +102,7 @@ services:
       - ${MONGO_RESTORE_SCRIPT_RELATIVE_PATH}:/restore_mongo.sh
       - ${MONGO_CREATE_INDEXES_SCRIPT_RELATIVE_PATH}:/create_indexes.js
       - ${MONGO_INIT_REPLICAS_SCRIPT_RELATIVE_PATH}:/init_replicas.js
-      - ${MONGO_SAMPLE_DATA_RELATIVE_PATH}:/dump
+      - ${MONGO_SAMPLE_DATA_RELATIVE_PATH:-./mongo/default_dump.txt}:/dump
 
   mongo-express:
     profiles:

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,5 +1,13 @@
 # JPO-UTILS Release Notes
 
+## Version 2.1.1
+----------------------------------------
+### **Summary**
+In this hotfix, a bug was fixed which required manual configuration of the mongodb sample data environment variable (MONGO_SAMPLE_DATA_RELATIVE_PATH) to be set before building. This is now defaulted correctly and runs without any additional configuration. 
+
+Enhancements in this release:
+- [USDOT PR 42](https://github.com/usdot-jpo-ode/jpo-utils/pull/42): Hotfix/2.1.1: Setting MongoDB Sample Data ENV
+
 ## Version 2.1.0
 ----------------------------------------
 ### **Summary**
@@ -22,7 +30,6 @@ Enhancements in this release:
 - [CDOT PR 21](https://github.com/CDOT-CV/jpo-utils/pull/21): Supporting MongoDB Sample Data Initialization
 - [CDOT PR 22](https://github.com/CDOT-CV/jpo-utils/pull/22): Update Intersection API Topic and Collection Names
 - [CDOT PR 23](https://github.com/CDOT-CV/jpo-utils/pull/23): Custom Kafka Retention ms
-- [CDOT PR 26](https://github.com/CDOT-CV/jpo-utils/pull/26): Defaulting Mongo Sample Data Dump Path
 - [USDOT PR 34](https://github.com/usdot-jpo-ode/jpo-utils/pull/34): Feature/deduplicated processed bsm
 - [USDOT PR 35](https://github.com/usdot-jpo-ode/jpo-utils/pull/35): Jikkou Image Updates
 - [USDOT PR 36](https://github.com/usdot-jpo-ode/jpo-utils/pull/36): Confluent Cloud Topic Creation

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -22,6 +22,7 @@ Enhancements in this release:
 - [CDOT PR 21](https://github.com/CDOT-CV/jpo-utils/pull/21): Supporting MongoDB Sample Data Initialization
 - [CDOT PR 22](https://github.com/CDOT-CV/jpo-utils/pull/22): Update Intersection API Topic and Collection Names
 - [CDOT PR 23](https://github.com/CDOT-CV/jpo-utils/pull/23): Custom Kafka Retention ms
+- [CDOT PR 26](https://github.com/CDOT-CV/jpo-utils/pull/26): Defaulting Mongo Sample Data Dump Path
 - [USDOT PR 34](https://github.com/usdot-jpo-ode/jpo-utils/pull/34): Feature/deduplicated processed bsm
 - [USDOT PR 35](https://github.com/usdot-jpo-ode/jpo-utils/pull/35): Jikkou Image Updates
 - [USDOT PR 36](https://github.com/usdot-jpo-ode/jpo-utils/pull/36): Confluent Cloud Topic Creation

--- a/mongo/restore_mongo.sh
+++ b/mongo/restore_mongo.sh
@@ -23,7 +23,7 @@ done
 echo "Replica set initialized and primary node is ready!"
 
 # Restore data if sample data path is provided
-if [ "${MONGO_SAMPLE_DATA_RELATIVE_PATH}" != "" ]; then
+if [ "${MONGO_SAMPLE_DATA_RELATIVE_PATH}" != "./mongo/default_dump.txt" ]; then
     echo "Restoring mongo data"
 
     # Ensure username and password are set
@@ -35,6 +35,6 @@ if [ "${MONGO_SAMPLE_DATA_RELATIVE_PATH}" != "" ]; then
 
     mongorestore --host mongo --username "${MONGO_ADMIN_DB_USER}" --password "${MONGO_ADMIN_DB_PASS}" --authenticationDatabase admin /dump
 else
-    echo "No sample data path provided. Skipping data restore."
+    echo "No sample data path provided. Skipping data restore. './mongo/default_dump.txt' is intentionally ignored"
 fi
 echo "Restore Done Dumping"

--- a/sample.env
+++ b/sample.env
@@ -121,7 +121,7 @@ MONGO_CREATE_INDEXES_SCRIPT_RELATIVE_PATH="./mongo/create_indexes.js"
 MONGO_MANAGE_VOLUMES_SCRIPT_RELATIVE_PATH="./mongo/manage_volume.js"
 # Relative path from this directory to a mongodump directory. Will not import data if blank.
 # Ensure that MONGO_DATA_RETENTION_SECONDS is long enough to not remove the imported data
-MONGO_SAMPLE_DATA_RELATIVE_PATH=""
+MONGO_SAMPLE_DATA_RELATIVE_PATH="./mongo/default_dump.txt"
 
 
 


### PR DESCRIPTION
In this hotfix, a bug was fixed which required manual configuration of the mongodb sample data environment variable (MONGO_SAMPLE_DATA_RELATIVE_PATH) to be set before building. This is now defaulted correctly and runs without any additional configuration.