### PR TITLE
Hotfix/2.1.2 - Adding Default MongoDB Volume Paths

### DIFF
--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -90,7 +90,7 @@ services:
       MONGO_DATA_RETENTION_SECONDS: ${MONGO_DATA_RETENTION_SECONDS:-5184000}
       MONGO_ASN_RETENTION_SECONDS: ${MONGO_ASN_RETENTION_SECONDS:-86400}
 
-      MONGO_SAMPLE_DATA_RELATIVE_PATH: ${MONGO_SAMPLE_DATA_RELATIVE_PATH}
+      MONGO_SAMPLE_DATA_RELATIVE_PATH: ${MONGO_SAMPLE_DATA_RELATIVE_PATH:-./mongo/dump}
 
       MONGO_INDEX_CREATE_ODE: ${MONGO_INDEX_CREATE_ODE:-true}
       MONGO_INDEX_CREATE_GEOJSONCONVERTER: ${MONGO_INDEX_CREATE_GEOJSONCONVERTER:-true}
@@ -98,11 +98,11 @@ services:
       MONGO_INDEX_CREATE_DEDUPLICATOR: ${MONGO_INDEX_CREATE_DEDUPLICATOR:-false}
     entrypoint: ["/bin/bash", "-c", "./setup_mongo.sh && ./restore_mongo.sh"]
     volumes:
-      - ${MONGO_SETUP_SCRIPT_RELATIVE_PATH}:/setup_mongo.sh
-      - ${MONGO_RESTORE_SCRIPT_RELATIVE_PATH}:/restore_mongo.sh
-      - ${MONGO_CREATE_INDEXES_SCRIPT_RELATIVE_PATH}:/create_indexes.js
-      - ${MONGO_INIT_REPLICAS_SCRIPT_RELATIVE_PATH}:/init_replicas.js
-      - ${MONGO_SAMPLE_DATA_RELATIVE_PATH:-./mongo/default_dump.txt}:/dump
+      - ${MONGO_SETUP_SCRIPT_RELATIVE_PATH:-./mongo/setup_mongo.sh}:/setup_mongo.sh
+      - ${MONGO_RESTORE_SCRIPT_RELATIVE_PATH:-./mongo/restore_mongo.sh}:/restore_mongo.sh
+      - ${MONGO_CREATE_INDEXES_SCRIPT_RELATIVE_PATH:-./mongo/create_indexes.js}:/create_indexes.js
+      - ${MONGO_INIT_REPLICAS_SCRIPT_RELATIVE_PATH:-./mongo/init_replicas.js}:/init_replicas.js
+      - ${MONGO_SAMPLE_DATA_RELATIVE_PATH:-./mongo/dump}:/dump
 
   mongo-express:
     profiles:

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,5 +1,13 @@
 # JPO-UTILS Release Notes
 
+## Version 2.1.2
+----------------------------------------
+### **Summary**
+In this hotfix, default values were added for all MongoDB docker-compose dynamic volumes. This enables operation without setting any of the MONGO_*_RELATIVE_PATH variables, reducing integration workload for parent projects using this as a submodule. 
+
+Enhancements in this release:
+- [USDOT PR 44](https://github.com/usdot-jpo-ode/jpo-utils/pull/44): Hotfix/2.1.2: Adding Default MongoDB Volume Paths
+
 ## Version 2.1.1
 ----------------------------------------
 ### **Summary**

--- a/mongo/restore_mongo.sh
+++ b/mongo/restore_mongo.sh
@@ -23,18 +23,14 @@ done
 echo "Replica set initialized and primary node is ready!"
 
 # Restore data if sample data path is provided
-if [ "${MONGO_SAMPLE_DATA_RELATIVE_PATH}" != "./mongo/default_dump.txt" ]; then
-    echo "Restoring mongo data"
+echo "Restoring mongo data"
 
-    # Ensure username and password are set
-    if [ -z "${MONGO_ADMIN_DB_USER}" ] || [ -z "${MONGO_ADMIN_DB_PASS}" ]; then
-        echo "Error: MONGO_ADMIN_DB_USER or MONGO_ADMIN_DB_PASS is not set."
-        exit 1
-    fi
-    echo "Restore Calling Dump"
-
-    mongorestore --host mongo --username "${MONGO_ADMIN_DB_USER}" --password "${MONGO_ADMIN_DB_PASS}" --authenticationDatabase admin /dump
-else
-    echo "No sample data path provided. Skipping data restore. './mongo/default_dump.txt' is intentionally ignored"
+# Ensure username and password are set
+if [ -z "${MONGO_ADMIN_DB_USER}" ] || [ -z "${MONGO_ADMIN_DB_PASS}" ]; then
+    echo "Error: MONGO_ADMIN_DB_USER or MONGO_ADMIN_DB_PASS is not set."
+    exit 1
 fi
+echo "Restore Calling Dump"
+
+mongorestore --host mongo --username "${MONGO_ADMIN_DB_USER}" --password "${MONGO_ADMIN_DB_PASS}" --authenticationDatabase admin /dump
 echo "Restore Done Dumping"

--- a/sample.env
+++ b/sample.env
@@ -121,7 +121,7 @@ MONGO_CREATE_INDEXES_SCRIPT_RELATIVE_PATH="./mongo/create_indexes.js"
 MONGO_MANAGE_VOLUMES_SCRIPT_RELATIVE_PATH="./mongo/manage_volume.js"
 # Relative path from this directory to a mongodump directory. Will not import data if blank.
 # Ensure that MONGO_DATA_RETENTION_SECONDS is long enough to not remove the imported data
-MONGO_SAMPLE_DATA_RELATIVE_PATH="./mongo/default_dump.txt"
+MONGO_SAMPLE_DATA_RELATIVE_PATH="./mongo/dump"
 
 
 


### PR DESCRIPTION
Adding default values for MongoDB docker-compose dynamic volume paths. This enables operation without setting any of the MONGO_*_RELATIVE_PATH variables, reducing integration workload for parent projects using this as a submodule. 
Additional changes:
- updating default MONGO_SAMPLE_DATA_RELATIVE_PATH from ./mongo/default_dump.txt to ./mongo/dump
- Updating logic in mongo/restore_mongo.sh to remove skipping of mount on default value

Testing:
- To test the changes in this PR, ensure that the COMPOSE_PROFILES variable includes all or mongo_full, then build docker-compose-mongo.yml. Ensure that the build succeeds without any environment variables (other than COMPOSE_PROFILES)