### PR TITLE
Hotfix 2.1.3: JPO-ODE KTable Topic Addition

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,5 +1,13 @@
 # JPO-UTILS Release Notes
 
+## Version 2.1.3
+----------------------------------------
+### **Summary**
+In this hotfix, a new topic was added to support the latest jpo-ode hotfix to address a bug regarding its handling of the TMC generated TIM messages within a Kafka Streams KTable.
+
+Enhancements in this release:
+- [USDOT PR 48](https://github.com/usdot-jpo-ode/jpo-utils/pull/48): Hotfix 2.1.3: JPO-ODE KTable Topic Addition
+
 ## Version 2.1.2
 ----------------------------------------
 ### **Summary**

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -6,7 +6,7 @@
 In this hotfix, a new topic was added to support the latest jpo-ode hotfix to address a bug regarding its handling of the TMC generated TIM messages within a Kafka Streams KTable.
 
 Enhancements in this release:
-- [USDOT PR 48](https://github.com/usdot-jpo-ode/jpo-utils/pull/48): Hotfix 2.1.3: JPO-ODE KTable Topic Addition
+- [USDOT PR 49](https://github.com/usdot-jpo-ode/jpo-utils/pull/49): Hotfix 2.1.3: JPO-ODE KTable Topic Addition
 
 ## Version 2.1.2
 ----------------------------------------

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -59,6 +59,7 @@ apps:
       - topic.OdeTimJsonTMCFiltered
       - topic.OdeTimBroadcastJson
       - topic.J2735TimBroadcastJson
+      - topic.OdeTimKTableJson
       - topic.FilteredOdeTimJson
       - topic.OdeDriverAlertJson
       - topic.Asn1DecoderInput


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
In this hotfix, a new topic was added to support the latest jpo-ode hotfix to address a bug regarding its handling of the TMC generated TIM messages within a Kafka Streams KTable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is necessary to ensure all required topics are created on runtime for Kafka deployments that don't allow for automatically created topics.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally and in CDOT's GCP GKE deployment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
